### PR TITLE
enabling multi-region support with dcos_core module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Backup Files
+*.bak
+
 
 ### Terraform ###
 # Terraform - https://terraform.io/

--- a/ee/dcos-versions/1.11.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.11.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.11.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.11.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.11.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.11.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.11.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.11.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.11.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.11.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.11.5/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.11.5/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.11.6/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.11.6/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.11.7/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.11.7/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.11.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.11.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.12.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.12.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/1.12.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/1.12.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/ee/dcos-versions/master/dcos-bootstrap/templates/upgrade/run.sh
+++ b/ee/dcos-versions/master/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.10.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.10.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
@@ -79,7 +79,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.10.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.10.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -79,7 +79,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.10.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.10.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -79,7 +79,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.10.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.10.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -78,7 +78,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.10.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.10.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -78,7 +78,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.10.5/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.10.5/dcos-bootstrap/templates/upgrade/run.sh
@@ -79,7 +79,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.10.6/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.10.6/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.10.7/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.10.7/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.10.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.10.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.5/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.5/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.6/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.6/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.7/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.7/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.12.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.12.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.12.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.12.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.5/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.5/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.6/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.6/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.7/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.7/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/1.9.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.9.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -76,7 +76,7 @@ EOF
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current

--- a/open/dcos-versions/master/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/master/dcos-bootstrap/templates/upgrade/run.sh
@@ -103,7 +103,7 @@ cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo
 cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/license.txt file"; else echo "copied file /tmp/license.txt to ~/genconf"; fi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
-PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
+PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g;s/,$//;s/"//g')
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current


### PR DESCRIPTION
When using the remote region, and attempting to upgrade, there is an issue where terraform fails with this error below

```
$ terraform apply -var dcos_install_mode=upgrade
....
Error: Error refreshing state: 1 error(s) occurred:

* module.spoke-1.module.dcos-install.module.dcos-bootstrap-install.module.dcos-bootstrap.data.template_file.script: 1 error(s) occurred:

* module.spoke-1.module.dcos-install.module.dcos-bootstrap-install.module.dcos-bootstrap.data.template_file.script: data.template_file.script: failed to render : element: element() may not be used with an empty list
```
 

This is because during the remote region, the master list is empty since it was never needed and provided and there is an interpolation logic that evaluates to element([],0) which causes terraform to error. The change below updates all the dcos core logic to evaluate an empty string list instead like element([""],0) which resolves the problem but it requires all update logic to be updated.

 

Because this is a change that requires all versions to be updated during the update step, it is tedious to update all of this manually, so a small script below was run to make this change globally. It was also a nice exercise. 

 

Commands to update all terraform script

```
$ cat sed.io
s/.*PREVIOUS_DCOS_VERSION=$(curl.*/PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(concat(compact(split("\\n - ","${dcos_master_list}")), list("")),"${dcos_previous_version_master_index}")}\/dcos-metadata\/dcos-version.json | grep version | cut -d ":" -f2 | sed 's\/ \/\/g;s\/,$\/\/;s\/\"\/\/g')/g
$ grep -r . -e "dcos-metadata/dcos-version.json | grep version" | grep -v terraform.tfstate | cut -d':' -f1 | xargs -L1 sed -i.bak -f sed.io
```