### PR TITLE
core: completed retries on failed downloads on previous versions

### DIFF
--- a/open/dcos-versions/1.11.0/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/1.11.0/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/open/dcos-versions/1.11.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.1/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/1.11.1/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/open/dcos-versions/1.11.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.2/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/1.11.2/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/open/dcos-versions/1.11.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.3/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/1.11.3/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/open/dcos-versions/1.11.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.4/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/1.11.4/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/open/dcos-versions/1.11.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/open/dcos-versions/1.11.5/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/1.11.5/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/open/dcos-versions/1.11.5/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.11.5/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/open/dcos-versions/1.12.2/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/1.12.2/dcos-bootstrap/templates/install/run.sh
@@ -98,7 +98,7 @@ ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_s
 ${dcos_enable_mesos_input_plugin == "" ? "" : "enable_mesos_input_plugin: ${dcos_enable_mesos_input_plugin}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/open/dcos-versions/1.12.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.12.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -105,7 +105,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/open/dcos-versions/1.12.3/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/1.12.3/dcos-bootstrap/templates/install/run.sh
@@ -98,7 +98,7 @@ ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_s
 ${dcos_enable_mesos_input_plugin == "" ? "" : "enable_mesos_input_plugin: ${dcos_enable_mesos_input_plugin}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/open/dcos-versions/1.12.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.12.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -105,7 +105,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/open/dcos-versions/1.8/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/1.8/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx:1.15.0) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/open/dcos-versions/1.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/1.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx:1.15.0) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/open/dcos-versions/master/dcos-bootstrap/templates/install/run.sh
+++ b/open/dcos-versions/master/dcos-bootstrap/templates/install/run.sh
@@ -98,7 +98,7 @@ ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_s
 ${dcos_enable_mesos_input_plugin == "" ? "" : "enable_mesos_input_plugin: ${dcos_enable_mesos_input_plugin}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/open/dcos-versions/master/dcos-bootstrap/templates/upgrade/run.sh
+++ b/open/dcos-versions/master/dcos-bootstrap/templates/upgrade/run.sh
@@ -105,7 +105,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current


### PR DESCRIPTION
This PR is to keep the same features that were available on the EE module of retries when there is a network interruption that occurs when downloading the 1 GB+ dcos_generate_config.sh.