### PR TITLE
added new releases

### DIFF
--- a/download-variables.tf
+++ b/download-variables.tf
@@ -17,10 +17,12 @@ variable "dcos_ee_download_path" {
     "1.12.1"       = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.12.1/commit/b7f04138fbb43f81a157fbd1f64904681532f61e/dcos_generate_config.ee.sh"
     "1.12.2"       = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.12.2/commit/c3af9042b96c5f70ca304083d1ac760ccf82ad69/dcos_generate_config.ee.sh"
     "1.12.3"       = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.12.3/commit/e8ecb9c00dc5bdc27d830df0b7fc91b6311660b8/dcos_generate_config.ee.sh"
+    "1.12.4"       = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.12.4/commit/198591d29a833fd5dbe7d4200ba8ab80c6978968/dcos_generate_config.ee.sh"
     "1.13.0-alpha" = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.13.0-alpha/commit/4da3d45e19ce0c04193a237d5a170e0b08108305/dcos_generate_config.ee.sh"
     "1.13.0-beta"  = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.13.0-beta/commit/7d38a400be9f3773ec58fdbbe5e19a96ea8f9e59/dcos_generate_config.ee.sh"
     "1.13.0"       = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.13.0/commit/1ec160b03e26d6e951083f524945c1ed2af3f3a3/dcos_generate_config.ee.sh"
     "1.13.1"       = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.13.1/commit/5b1576c498bcebe234b7c68ad21e6a08101972fc/dcos_generate_config.ee.sh"
+    "1.13.2"       = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.13.2/commit/bd9ecda09dbe95fbc6a414cd8ef9a0e307526eb2/dcos_generate_config.ee.sh"
     "master"       = "https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh"
   }
 
@@ -81,10 +83,12 @@ variable "dcos_open_download_path" {
     "1.12.1"       = "https://downloads.dcos.io/dcos/stable/1.12.1/dcos_generate_config.sh"
     "1.12.2"       = "https://downloads.dcos.io/dcos/stable/1.12.2/dcos_generate_config.sh"
     "1.12.3"       = "https://downloads.dcos.io/dcos/stable/1.12.3/dcos_generate_config.sh"
+    "1.12.4"       = "https://downloads.dcos.io/dcos/stable/1.12.4/commit/a3ff57afc390e55bf7850b1c888110b9cfef4081/dcos_generate_config.sh"
     "1.13.0-alpha" = "https://downloads.dcos.io/dcos/stable/1.13.0-alpha/commit/633f96c6b97ee6b48eb20cbd06f92cbfc01a6622/dcos_generate_config.sh"
     "1.13.0-beta"  = "https://downloads.dcos.io/dcos/stable/1.13.0-beta/commit/ac4a32dbdcdb5a2edcb99a57ca80e0f77bdb553a/dcos_generate_config.sh"
     "1.13.0"       = "https://downloads.dcos.io/dcos/stable/1.13.0/commit/f5cb8649583bb43d0f7ad5b0b7a12c5333e9587f/dcos_generate_config.sh"
     "1.13.1"       = "https://downloads.dcos.io/dcos/stable/1.13.1/commit/f59e02457b5cd64ef14f94f79eb92db15b2d91f6/dcos_generate_config.sh"
+    "1.13.2"       = "https://downloads.dcos.io/dcos/stable/1.13.2/commit/a083f4c4b9a288e14e7413fd195c09378eab89b6/dcos_generate_config.sh"
     "master"       = "https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh"
   }
 


### PR DESCRIPTION
prepared, URLs may change within the release process.
going to be cherry-picked into `support/0.1.x` branch as soon as ready. 🎉 