### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Terraform module to install, upgrade, and modify nodes for DC/OS clusters in a
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | bootstrap\_private\_ip | Private IP bootstrap nginx is listening on. Used to build the bootstrap URL. | string | n/a | yes |
+| adminrouter\_grpc\_proxy\_port |  | string | `"12379"` | no |
 | custom\_dcos\_download\_path | insert location of dcos installer script (optional) | string | `""` | no |
 | dcos\_adminrouter\_tls\_1\_0\_enabled | Indicates whether to enable TLSv1 support in Admin Router. (optional) | string | `""` | no |
 | dcos\_adminrouter\_tls\_1\_1\_enabled | Indicates whether to enable TLSv1.1 support in Admin Router. (optional) | string | `""` | no |

--- a/config.yaml.tpl
+++ b/config.yaml.tpl
@@ -100,3 +100,4 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_enable_mesos_input_plugin == "" ? "" : "enable_mesos_input_plugin: ${dcos_enable_mesos_input_plugin}"}
 ${dcos_config == "" ? "" : "${dcos_config}"}
+${adminrouter_grpc_proxy_port == "" ? "" : "adminrouter_grpc_proxy_port: ${adminrouter_grpc_proxy_port}"}

--- a/examples/base/main.tf
+++ b/examples/base/main.tf
@@ -105,6 +105,7 @@ module "dcos-core-base-example" {
   dcos_ip_detect_contents                      = "${var.dcos_ip_detect_contents}"
   dcos_ip_detect_public_contents               = "${var.dcos_ip_detect_public_contents}"
   dcos_enable_mesos_input_plugin               = "${var.dcos_enable_mesos_input_plugin}"
+  adminrouter_grpc_proxy_port                  = "${var.adminrouter_grpc_proxy_port}"
 }
 
 output "config" {

--- a/main.tf
+++ b/main.tf
@@ -128,5 +128,6 @@ data "template_file" "config" {
     dcos_staged_package_storage_uri              = "${var.dcos_staged_package_storage_uri}"
     dcos_package_storage_uri                     = "${var.dcos_package_storage_uri}"
     dcos_enable_mesos_input_plugin               = "${var.dcos_enable_mesos_input_plugin}"
+    adminrouter_grpc_proxy_port                  = "${var.adminrouter_grpc_proxy_port}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -534,3 +534,8 @@ variable "dcos_calico_veth_mtu" {
   default     = ""
   description = "The MTU to set on the veth pair devices. (optional)"
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476